### PR TITLE
Add vconsole keymap to kernel cmdline

### DIFF
--- a/src/bootloaders/syslinux-common.c
+++ b/src/bootloaders/syslinux-common.c
@@ -103,6 +103,8 @@ bool syslinux_common_set_default_kernel(const BootManager *manager, const Kernel
         NcHashmapIter iter = { 0 };
         char *initrd_name = NULL;
         char *ucode_initrd = NULL;
+        const char *vc_keymap = NULL;
+        const char *vc_font = NULL;
         int timeout;
         struct SyslinuxContext *ctx = NULL;
 
@@ -122,6 +124,8 @@ bool syslinux_common_set_default_kernel(const BootManager *manager, const Kernel
         }
 
         timeout = boot_manager_get_timeout_value((BootManager *)manager);
+        vc_keymap = boot_manager_get_vconsole((BootManager *)manager, "KEYMAP");
+        vc_font = boot_manager_get_vconsole((BootManager *)manager, "FONT");
 
         /* No default kernel for set timeout */
         if (!default_kernel) {
@@ -192,6 +196,13 @@ bool syslinux_common_set_default_kernel(const BootManager *manager, const Kernel
                 /* Add Btrfs information if relevant */
                 if (root_dev->btrfs_sub) {
                         cbm_writer_append_printf(writer, "rootflags=subvol=%s ", root_dev->btrfs_sub);
+                }
+                /* Add VC settings if configured */
+                if (vc_keymap) {
+                        cbm_writer_append_printf(writer, "rd.vconsole.keymap=%s ", vc_keymap);
+                }
+                if (vc_font) {
+                        cbm_writer_append_printf(writer, "rd.vconsole.font=%s ", vc_font);
                 }
 
                 /* Write out the cmdline */

--- a/src/bootloaders/systemd-class.c
+++ b/src/bootloaders/systemd-class.c
@@ -237,6 +237,8 @@ bool sd_class_install_kernel(const BootManager *manager, const Kernel *kernel)
         autofree(char) *conf_path = NULL;
         const CbmDeviceProbe *root_dev = NULL;
         const char *os_name = NULL;
+        const char *vc_keymap = NULL;
+        const char *vc_font = NULL;
         autofree(char) *old_conf = NULL;
         autofree(CbmWriter) *writer = CBM_WRITER_INIT;
         NcHashmapIter iter = { 0 };
@@ -258,6 +260,8 @@ bool sd_class_install_kernel(const BootManager *manager, const Kernel *kernel)
         }
 
         os_name = boot_manager_get_os_name((BootManager *)manager);
+        vc_keymap = boot_manager_get_vconsole((BootManager *)manager, "KEYMAP");
+        vc_font = boot_manager_get_vconsole((BootManager *)manager, "FONT");
 
         /* Standard title + linux lines */
         cbm_writer_append_printf(writer, "title %s\n", os_name);
@@ -312,6 +316,13 @@ bool sd_class_install_kernel(const BootManager *manager, const Kernel *kernel)
         /* Add Btrfs information if relevant */
         if (root_dev->btrfs_sub) {
                 cbm_writer_append_printf(writer, "rootflags=subvol=%s ", root_dev->btrfs_sub);
+        }
+        /* Add VC settings if configured */
+        if (vc_keymap) {
+                cbm_writer_append_printf(writer, "rd.vconsole.keymap=%s ", vc_keymap);
+        }
+        if (vc_font) {
+                cbm_writer_append_printf(writer, "rd.vconsole.font=%s ", vc_font);
         }
 
         /* Finish it off with the command line options */

--- a/src/bootman/bootman.h
+++ b/src/bootman/bootman.h
@@ -217,6 +217,13 @@ const char *boot_manager_get_os_name(BootManager *manager);
 const char *boot_manager_get_os_id(BootManager *self);
 
 /**
+ * Return a value from the VC Keyamp.
+ *
+ * @note This string is owned by BootManager, do not modify or free
+ */
+const char *boot_manager_get_vconsole(BootManager *self, const char *key);
+
+/**
  * Discover a list of known kernels
  *
  * @return a newly allocated NcArray of Kernel's

--- a/src/bootman/bootman_private.h
+++ b/src/bootman/bootman_private.h
@@ -28,6 +28,7 @@ struct BootManager {
         char *kernel_dir;              /**<Kernel directory */
         const BootLoader *bootloader;  /**<Selected bootloader */
         CbmOsRelease *os_release;      /**<Parsed os-release file */
+        NcHashmap *vconsole;           /**<Parsed /etc/vconsole.conf */
         char *abs_bootdir;             /**<Real boot dir */
         SystemKernel sys_kernel;       /**<Native kernel info, if any */
         bool have_sys_kernel;          /**<Whether sys_kernel is set */


### PR DESCRIPTION
Detect and add the vconsole keymap (as configured in `/etc/vconsole.conf`) to the kernel cmdline. This ensures that the keymap in things like the LUKS password prompt are in line with the system.

See `man vconsole.conf` for details on how the configurations work.

Resolves getsolus/packages/issues/1544